### PR TITLE
LUA_VERSION_NUM

### DIFF
--- a/Src/LuaPlus/lua51-luaplus/src/lua.h
+++ b/Src/LuaPlus/lua51-luaplus/src/lua.h
@@ -13,7 +13,6 @@
 #include <stddef.h>
 
 
-#include "luaconf.h"
 
 
 #define LUA_VERSION	"Lua 5.1"
@@ -29,6 +28,7 @@
 /* option for multiple returns in `lua_pcall' and `lua_call' */
 #define LUA_MULTRET	(-1)
 
+#include "luaconf.h"
 
 /*
 ** pseudo-indices

--- a/Src/LuaPlus/lua53-luaplus/src/lua.h
+++ b/Src/LuaPlus/lua53-luaplus/src/lua.h
@@ -13,8 +13,6 @@
 #include <stddef.h>
 
 
-#include "luaconf.h"
-
 
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"3"
@@ -33,6 +31,7 @@
 /* option for multiple returns in 'lua_pcall' and 'lua_call' */
 #define LUA_MULTRET	(-1)
 
+#include "luaconf.h"
 
 /*
 ** Pseudo-indices


### PR DESCRIPTION
The definition of LUA_VERSION_NUM needs to be judged in LuaPlusConfig.h, but LUA_VERSION_NUM is defined after LuaPlusConfig.h